### PR TITLE
Terraform Registry release

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,46 +1,74 @@
-# Contributor Covenant Code of Conduct
-
-## Our Pledge
-
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
-
-## Our Standards
-
-Examples of behavior that contributes to creating a positive environment include:
-
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
-
+## Code of Conduct
+ 
+### Our Pledge
+ 
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+ 
+### Our Standards
+ 
+Examples of behavior that contributes to creating a positive environment
+include:
+ 
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+ 
 Examples of unacceptable behavior by participants include:
-
-- The use of sexualized language or imagery and unwelcome sexual attention or advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information, such as a physical or electronic address, without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
-
-## Scope
-
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at data_engineering@babbel.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
-
+ 
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+ 
+### Our Responsibilities
+ 
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+ 
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+ 
+### Scope
+ 
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+ 
+### Enforcement
+ 
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team via issues, or pinging on Github through @babbel/babbel-oss. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+ 
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+ 
+### Attribution
+ 
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+ 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,19 @@
 # Contributing
-
+ 
 When contributing to this repository, please first discuss the change you wish to make via issue,
 email, or any other method with the owners of this repository before making a change.
-
+ 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
-
+ 
+ 
+You can ping the OSS committee via @babbel/babbel-oss on github
+ 
 ## Pull Request Process
-
-1.  Ensure any install or build dependencies are removed before the end of the layer when doing a build.
-2.  Update the README.md with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations and container parameters.
-3.  Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-4.  You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
+ 
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a
+   build.
+2. Update the README.md with details of changes to the interface, this includes new environment
+   variables, exposed ports, useful file locations and container parameters.
+3. Increase the version numbers, if it applies, in any examples files and the README.md to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. Pull Request will be merged by the code owner of the project

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 [![Terraform Status](https://github.com/babbel/terraform-aws-ecs-fargate-scheduled-task/workflows/Lint/badge.svg)](https://github.com/babbel/terraform-aws-ecs-fargate-scheduled-task/actions)
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/babbel/terraform-aws-ecs-fargate-scheduled-task/blob/master/LICENCE)
+[![GitHub release](https://img.shields.io/github/release/babbel/terraform-aws-ecs-fargate-scheduled-task.svg)](https://github.com/babbel/terraform-aws-ecs-fargate-scheduled-task/releases)
 
 A Terraform module to create an ECS Fargate Task Definition which can be scheduled via CloudWatch Events, with the related CloudWatch Log Group and IAM resources.
+
+Available through the [Terraform registry](https://registry.terraform.io/modules/babbel/ecs-fargate-scheduled-task/aws).
 
 ## Assumptions
 
@@ -20,7 +23,7 @@ Here's the gist of using it via GitHub source:
 
 ```hcl
 module "fargate_task" {
-  source                  = "github.com/babbel/terraform-aws-ecs-fargate-scheduled-task"
+  source                  = "babbel/ecs-fargate-scheduled-task/aws"
   region                  = "eu-west-1"
   task_name               = "fargate-task"
   schedule_expression     = "rate(30 minutes)"


### PR DESCRIPTION
## Terraform Registry release

This PR updates the `README.md` with the source link of the Terraform Registry.

Edit: update `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` based on Babbel standards. 