### PR TITLE
Add support of ephemeral_storage

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -17,14 +17,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-
-      - name: Init
-        uses: hashicorp/terraform-github-actions/init@v0.4.6
-
-      - name: Format
-        uses: hashicorp/terraform-github-actions/fmt@v0.4.6
-
-      - name: Validate
-        uses: hashicorp/terraform-github-actions/validate@v0.4.6
+      - uses: hashicorp/setup-terraform@v1
+      
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+      
+      - name: Terraform Init
+        id: init
+        run: terraform init
+      
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
         env:
           AWS_DEFAULT_REGION: eu-west-1

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ MIT Licensed. See [LICENSE](https://github.com/babbel/terraform-aws-ecs-fargate-
 | task\_memory | (Optional) Memory value for the Fargate task | number | `"512"` | no |
 | task\_name | (Required) Name of the Fargate task | string | n/a | yes |
 | task\_policy | (Required) Path to the Task IAM Policy JSON file | string | n/a | yes |
+| ephemeral\_storage | (Optional) The amount(in GiB) of ephemeral storage to allocate for the task | number | n/a | no |
 | vpc\_security\_groups | (Required) List of security groups for the EC2 instance running the Fargate task | list(string) | n/a | yes |
 | vpc\_subnets | (Required) List of subnets were AWS will spawn an EC2 instance running the Fargate task | list(string) | n/a | yes |
 

--- a/main.tf
+++ b/main.tf
@@ -146,6 +146,13 @@ resource "aws_ecs_task_definition" "fargate_task" {
   cpu                      = var.task_cpu
   memory                   = var.task_memory
 
+  dynamic "ephemeral_storage" {
+    for_each = var.ephemeral_storage > 20 ? [var.ephemeral_storage] : []
+    content {
+      size_in_gib = var.ephemeral_storage
+    }
+  }
+
   execution_role_arn = var.task_execution_role_arn
   task_role_arn      = aws_iam_role.ecs_task_role.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "task_memory" {
   default     = 512
 }
 
+variable "ephemeral_storage" {
+  type        = number
+  description = "(Optional) The amount(in GiB) of ephemeral storage to allocate for the task"
+  default     = 0
+}
+
 variable "assign_public_ip" {
   type        = bool
   description = "(Optional) Assign a public IP to the EC2 instance running the Fargate task"
@@ -72,3 +78,5 @@ variable "logs_retention_days" {
   description = "(Optional) Retention days for logs of the Fargate task log group "
   default     = 14
 }
+
+


### PR DESCRIPTION
Hi,
AWS ECS introduced [ephemeral storage](https://aws.amazon.com/tw/about-aws/whats-new/2021/04/amazon-ecs-aws-fargate-configure-size-ephemeral-storage-tasks/) earlier this year, and aws provider [supports](https://github.com/hashicorp/terraform-provider-aws/pull/19694) it from v3.45.0.